### PR TITLE
Fix ignore patterns in locus analyze command

### DIFF
--- a/src/.locusignore
+++ b/src/.locusignore
@@ -1,70 +1,20 @@
 # File patterns to exclude from analysis
-# One pattern per line, supports glob patterns
+# One pattern per line, supports glob patterns and **/folder/** syntax
 # Lines starting with # are comments
+#
+# Note: The following are ALWAYS ignored by default in code:
+# - All dot-directories (.git, .venv, .cache, .pytest_cache, etc.)
+# - Common build dirs: build, dist, target, out, output, outputs
+# - Cache dirs: __pycache__, node_modules, .mypy_cache, .ruff_cache
+# - Temp dirs: tmp, temp, .tmp, .temp
+# - Log dirs: logs
+# - Common file patterns: *.pyc, *.pyo, *.log, *.swp, .DS_Store
 
-# Version control
-**/.git/**
-**/.hg/**
-**/.svn/**
-**/.bzr/**
-
-# Python
-**/__pycache__/**
-**/*.pyc
-**/*.pyo
-**/*.pyd
-**/.Python
-**/*.egg-info/**
-**/dist/**
-**/build/**
-**/.pytest_cache/**
-**/.mypy_cache/**
-**/.ruff_cache/**
-**/.coverage
-**/*.coverage
-**/.hypothesis/**
-
-# Virtual environments
-**/.venv/**
-**/venv/**
-**/.env/**
-**/env/**
-**/ENV/**
-
-# Node
-**/node_modules/**
-**/npm-debug.log
-**/yarn-error.log
-**/yarn-debug.log
-**/.npm/**
-**/.yarn/**
-
-# IDE
-**/.idea/**
-**/.vscode/**
-**/*.swp
-**/*.swo
-**/*~
-**/.DS_Store
-**/Thumbs.db
-
-# Build outputs
-**/out/**
-**/output/**
-**/outputs/**
-**/target/**
-**/bin/**
-**/obj/**
-
-# Logs
-**/logs/**
-**/*.log
-
-# Temporary files
-**/tmp/**
-**/temp/**
-**/.tmp/**
-**/.temp/**
+# Project-specific patterns (add your custom patterns here)
+# Examples:
+# data/
+# *.db
+# docs/internal/
 
 # Config files to exclude
 .locusignore

--- a/src/.locusignore
+++ b/src/.locusignore
@@ -4,11 +4,16 @@
 #
 # Note: The following are ALWAYS ignored by default in code:
 # - All dot-directories (.git, .venv, .cache, .pytest_cache, etc.)
-# - Common build dirs: build, dist, target, out, output, outputs
+# - Common build dirs: build, dist, target, out, output, outputs, bin, obj
+# - Virtual environments: venv, env, .env, .venv, ENV
 # - Cache dirs: __pycache__, node_modules, .mypy_cache, .ruff_cache
 # - Temp dirs: tmp, temp, .tmp, .temp
 # - Log dirs: logs
 # - Common file patterns: *.pyc, *.pyo, *.log, *.swp, .DS_Store
+#
+# IMPORTANT: The above directories are hardcoded and CANNOT be overridden.
+# If you need to include files from these directories, you must modify
+# ALWAYS_IGNORE_DIRS in src/locus/utils/helpers.py
 
 # Project-specific patterns (add your custom patterns here)
 # Examples:

--- a/src/locus/utils/helpers.py
+++ b/src/locus/utils/helpers.py
@@ -18,6 +18,7 @@ ALWAYS_IGNORE_DIRS = {
     "venv",
     "env",
     ".env",
+    "ENV",  # Uppercase virtualenv (common on Windows)
     "__pycache__",
     "node_modules",
     "build",
@@ -29,6 +30,8 @@ ALWAYS_IGNORE_DIRS = {
     "out",
     "output",
     "outputs",
+    "bin",  # Common build output (C/C++, .NET, etc.)
+    "obj",  # Common build output (.NET, C++, etc.)
     # Cache directories
     ".pytest_cache",
     ".mypy_cache",


### PR DESCRIPTION
- Fixed **/folder/** patterns by adding proper gitignore-style support
- Added automatic ignoring of all dot-directories (.cache, .pytest_cache, etc.)
- Added 'out', 'output', 'outputs' to ALWAYS_IGNORE_DIRS
- Added cache dirs (.pytest_cache, .mypy_cache, .ruff_cache, .hypothesis)
- Added temp dirs (tmp, temp, .tmp, .temp) and logs dir
- Enhanced DEFAULT_IGNORE_PATTERNS with *.log, *.swo, *~, Thumbs.db
- Simplified .locusignore by removing duplicates (now handled in code)
- Improved is_path_ignored() to properly handle **/folder/** patterns

This fixes the issue where **/output/** pattern wasn't working because fnmatch doesn't support ** syntax. Now we parse these patterns and check if the folder name appears anywhere in the path.