### PR TITLE
Add ignore files support for locus analyze

### DIFF
--- a/src/locus/utils/helpers.py
+++ b/src/locus/utils/helpers.py
@@ -130,8 +130,17 @@ def is_path_ignored(
         # Handle **/folder/** patterns (gitignore-style)
         if pattern.startswith("**/") and pattern.endswith("/**"):
             folder_name = pattern[3:-3]  # Extract 'folder' from '**/folder/**'
-            if folder_name in path_parts:
-                return True
+            # The **/folder/** pattern means files INSIDE matching directories
+            # So we check all path components except the last one (which is the file/final dir)
+            if any(ch in folder_name for ch in "*?["):
+                # Use fnmatch to match against each path component (except last)
+                for part in path_parts[:-1]:
+                    if fnmatch.fnmatch(part, folder_name):
+                        return True
+            else:
+                # Exact match for folder name without wildcards (except last)
+                if folder_name in path_parts[:-1]:
+                    return True
             continue
 
         # Handle **/folder patterns


### PR DESCRIPTION
Previously, patterns like **/*.egg-info/** did not work correctly because the code only supported exact folder name matching. Now fnmatch is used to match glob patterns (e.g., *.egg-info) against path components.

Changes:
- Updated is_path_ignored() to handle wildcards in **/pattern/** syntax
- Added logic to check only non-final path components (files INSIDE dirs)
- Added comprehensive tests for glob wildcard patterns
- Added tests for exact folder patterns to ensure no regression

Fixes:
- **/*.egg-info/** now correctly ignores test_pkg.egg-info/ directories
- **/*cache/** now correctly ignores .pytest_cache/, .mypy_cache/, etc.
- Exact patterns like **/build/** still work as before

Tests:
- test_is_path_ignored_with_glob_wildcards: Tests **/*.egg-info/** and **/*cache/**
- test_is_path_ignored_exact_folder_pattern: Tests **/build/** exact matching